### PR TITLE
Update setup.sh

### DIFF
--- a/Ecole/ft_services/aborboll/setup.sh
+++ b/Ecole/ft_services/aborboll/setup.sh
@@ -17,12 +17,8 @@ eval $(minikube docker-env)
 minikube addons enable dashboard
 minikube addons enable metrics-server
 minikube addons enable logviewer
+minikube addons enable metallb
 
-# https://metallb.universe.tf/installation/#installation-by-manifest
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml
-# On first install only
-kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)" > /dev/null
 kubectl apply -f metallb.yaml
 
 # Build process


### PR DESCRIPTION
Metallb is among the minikube addons. I think it is cleaner to remove the installation via manifest and add the installation in a simple command as you have for dashboard, metrics-server and logviewer.